### PR TITLE
ARXIVNG-1920 added AUTH_UPDATED_SESSION_REF to support renaming request.session to .auth

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,3 +1,5 @@
+# Decision log
+
 1. To minimize complexity, we'll start with a managed Redis cluster in AWS
    ElastiCache. In the future, we may consider running our own HA key-value
    store, and potentially evaluate performance of other backends.
@@ -5,3 +7,14 @@
    can decide what "admin", "moderator", etc means and inject the relevant
    scopes. Later on, we will have an RBAC system. We therefore screen off the
    scope-determination concern from the session-creation concern.
+
+## 2019-02-28 Rename ``request.session`` to ``request.auth``
+
+The auth middleware in ``arxiv.users`` package hands the authenticated session
+on ``flask.session``, which clobbers the built-in Flask session interface. This
+is a design flaw that's blocking other work. ARXIVNG-1920
+
+Starting with v0.3.1, set ``AUTH_UPDATED_SESSION_REF=True`` in your
+application config to rename ``request.session`` to ``request.auth``.
+``request.auth`` will be the default name for the authenticated session
+starting in v0.4.1.

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ arxiv-base = "==0.14.3"
 authlib = "*"
 openapi-spec-validator = "*"
 bleach = "*"
+"4010dd8" = {path = "./users"}
 
 [dev-packages]
 mimesis = "==2.1.0"

--- a/Pipfile
+++ b/Pipfile
@@ -22,7 +22,6 @@ arxiv-base = "==0.14.3"
 authlib = "*"
 openapi-spec-validator = "*"
 bleach = "*"
-"4010dd8" = {path = "./users"}
 
 [dev-packages]
 mimesis = "==2.1.0"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ TLS is considered an infrastructure concern, and is therefore out of scope
 - Clean up and document authenticator service.
 - Fuzz testing registration?
 
+## Updates
+
+- Starting with v0.3.1, set ``AUTH_UPDATED_SESSION_REF=True`` in your
+  application config to rename ``request.session`` to ``request.auth``.
+  ``request.auth`` will be the default name for the authenticated session
+  starting in v0.4.1.
+
 ## Dependencies
 
 We use pipenv to manage dependencies. To install the dependencies for this

--- a/users/arxiv/users/auth/__init__.py
+++ b/users/arxiv/users/auth/__init__.py
@@ -2,6 +2,7 @@
 
 from typing import Optional, Union
 from datetime import datetime
+import warnings
 from pytz import UTC
 from flask import Flask, request, Response, make_response, redirect, url_for
 from werkzeug.http import parse_cookie
@@ -121,7 +122,19 @@ class Auth(object):
 
         # Attach the session to the request so that other
         # components can access it easily.
-        request.session = session
+        if self.app.config.get('AUTH_UPDATED_SESSION_REF'):
+            request.auth = session
+        else:
+            # This clobbers the built-in Flask session interface. This is a
+            # design flaw that's blocking other work. This is deprecated and
+            # will be removed in 0.4.1.
+            warnings.warn(
+                "Accessing the authenticated session via request.session is"
+                " deprecated, and will be removed in 0.4.1. Use request.auth"
+                " instead. ARXIVNG-1920.",
+                DeprecationWarning
+            )
+            request.session = session
 
     def detect_and_clobber_dupe_cookies(self) -> Optional[Response]:
         """

--- a/users/setup.py
+++ b/users/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-auth',
-    version='0.2.7rc1',
+    version='0.3.1',
     packages=[f'arxiv.{package}' for package
               in find_packages('./arxiv', exclude=['*test*'])],
     install_requires=[


### PR DESCRIPTION
The auth middleware in ``arxiv.users`` package hands the authenticated session on ``flask.session``, which clobbers the built-in Flask session interface. This is a design flaw that's blocking other work.

Starting with v0.3.1, set ``AUTH_UPDATED_SESSION_REF=True`` in your application config to rename ``request.session`` to ``request.auth``. ``request.auth`` will be the default name for the authenticated session starting in v0.4.1.