### PR TITLE
ARXIVOPS-956: update text on login page to reflect privacy discussion

### DIFF
--- a/accounts/accounts/templates/accounts/login.html
+++ b/accounts/accounts/templates/accounts/login.html
@@ -47,7 +47,7 @@
 
     <h2>If you've never logged in to arXiv.org</h2>
       <p><a class="button is-link" href="{{ url_for('register') }}?submit=Register+for+the+first+time">Register for the first time</a></p>
-      <p>Registration is required to submit or update papers.</p>
+      <p>Registration is required to submit or update papers, but is not necessary to view them.</p>
   </div>
 </div>
 {% endblock inner_content %}


### PR DESCRIPTION
<img width="551" alt="Screenshot 2019-08-21 09 10 09" src="https://user-images.githubusercontent.com/746253/63434691-91143280-c3f3-11e9-822f-b44983fb8a07.png">

Also staged on beta: https://beta.arxiv.org/login