### PR TITLE
Adds some tests for an already logged in user

### DIFF
--- a/accounts/accounts/config.py
+++ b/accounts/accounts/config.py
@@ -48,7 +48,7 @@ DEFAULT_LOGOUT_REDIRECT_URL = os.environ.get(
 )
 
 LOGIN_REDIRECT_REGEX = os.environ.get('LOGIN_REDIRECT_REGEX',
-                                      fr'(/.*)|(https://([a-zA-Z0-9\-.])*{re.escape(BASE_SERVER)}/.*)')
+                                      fr'(^/.*)|(^https://([a-zA-Z0-9\-.])*{re.escape(BASE_SERVER)}/.*)')
 """Regex to check next_page of /login.
 
 Only next_page values that match this regex will be allowed. All

--- a/accounts/accounts/controllers/authentication.py
+++ b/accounts/accounts/controllers/authentication.py
@@ -32,6 +32,7 @@ from arxiv.base import logging
 from arxiv.users.domain import User, Authorizations, Session
 from accounts.services import legacy, SessionStore, users
 from accounts import config
+from accounts.next_page import good_next_page
 
 from .util import MultiCheckboxField, OptGroupSelectField
 
@@ -132,7 +133,7 @@ def login(method: str, form_data: MultiDict, ip: str,
             'classic_cookie': (c_cookie, c_session.expires)
         }
     })
-    next_page = next_page if good_next_page(next_page) else config.DEFAULT_LOGIN_REDIRECT_URL
+    next_page = good_next_page(next_page)
     return data, status.HTTP_303_SEE_OTHER, {'Location': next_page}
 
 
@@ -216,9 +217,3 @@ def _do_login(auths: Authorizations, ip: str, tracking_cookie: str,
 def _do_logout(classic_session_cookie: str) -> None:
     with legacy.transaction():
         legacy.invalidate(classic_session_cookie)
-
-
-def good_next_page(next_page: str) -> bool:
-    """True if next_page is a valid query parameter for use with the login page."""
-    return next_page == config.DEFAULT_LOGIN_REDIRECT_URL \
-        or re.search(config.login_redirect_pattern, next_page)

--- a/accounts/accounts/next_page.py
+++ b/accounts/accounts/next_page.py
@@ -1,0 +1,15 @@
+"""Next page handling."""
+import re
+
+from accounts import config
+
+def good_next_page(next_page: str) -> str:
+    """Checks if a next_page is good and returns it.
+
+    If not good, it will return the default.
+    """
+    good = (next_page and len(next_page) < 300 and
+            (next_page == config.DEFAULT_LOGIN_REDIRECT_URL
+             or re.match(config.login_redirect_pattern, next_page))
+            )
+    return next_page if good else config.DEFAULT_LOGIN_REDIRECT_URL

--- a/accounts/accounts/routes/ui.py
+++ b/accounts/accounts/routes/ui.py
@@ -11,6 +11,7 @@ from arxiv import status
 from arxiv.users import domain
 from arxiv.base import logging
 
+from accounts.next_page import good_next_page
 from accounts.controllers import captcha_image, registration, authentication
 
 EASTERN = timezone('US/Eastern')
@@ -29,8 +30,7 @@ def anonymous_only(func: Callable) -> Callable:
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         if request.auth:
-            next_page = request.args.get('next_page',
-                                         current_app.config['DEFAULT_LOGIN_REDIRECT_URL'])
+            next_page = good_next_page(request.args.get('next_page',None))
             return make_response(redirect(next_page, code=status.HTTP_303_SEE_OTHER))
         else:
             return func(*args, **kwargs)


### PR DESCRIPTION
Refactors out the common code for `/login` and the `anonymous_only()` wrapper.

Adds some more tests for when a user is already logged in.

The next_page handling in this case needs to work well to support authentication to systems like arxiv-check.