### PR TITLE
Fixes off site `next_page` redirect when already logged in

### DIFF
--- a/accounts/accounts/config.py
+++ b/accounts/accounts/config.py
@@ -47,8 +47,10 @@ DEFAULT_LOGOUT_REDIRECT_URL = os.environ.get(
     'https://arxiv.org'
 )
 
+_relative_urls = r"(^\/(?:[^\/]+\/)*[^\/]+$)"
+_absolute_urls = rf"(^https://([a-zA-Z0-9\-.])*{re.escape(BASE_SERVER)}/.*$)"
 LOGIN_REDIRECT_REGEX = os.environ.get('LOGIN_REDIRECT_REGEX',
-                                      fr'(^/.*)|(^https://([a-zA-Z0-9\-.])*{re.escape(BASE_SERVER)}/.*)')
+                                      f"{_relative_urls}|{_absolute_urls}")
 """Regex to check next_page of /login.
 
 Only next_page values that match this regex will be allowed. All

--- a/accounts/accounts/routes/ui.py
+++ b/accounts/accounts/routes/ui.py
@@ -110,10 +110,10 @@ def register() -> Response:
     """Interface for creating new accounts."""
     captcha_secret = current_app.config['CAPTCHA_SECRET']
     ip_address = request.remote_addr
-    next_page = _checked_next_page(otherwise=url_for('account'))
+    safe_next_page = _checked_next_page(otherwise=url_for('account'))
     data, code, headers = registration.register(request.method, request.form,
                                                 captcha_secret, ip_address,
-                                                next_page)
+                                                safe_next_page)
 
     # Flask puts cookie-setting methods on the response, so we do that here
     # instead of in the controller.
@@ -132,11 +132,11 @@ def login() -> Response:
     """User can log in with username and password, or permanent token."""
     ip_address = request.remote_addr
     form_data = request.form
-    next_page = _checked_next_page()
-    logger.debug('Request to log in, then redirect to %s', next_page)
+    safe_next_page = _checked_next_page()
+    logger.debug('Request to log in, then redirect to %s', safe_next_page)
     data, code, headers = authentication.login(request.method,
                                                form_data, ip_address,
-                                               next_page)
+                                               safe_next_page)
     data.update({'pagetitle': 'Log in to arXiv'})
     # Flask puts cookie-setting methods on the response, so we do that here
     # instead of in the controller.
@@ -162,10 +162,10 @@ def logout() -> Response:
     classic_cookie_key = current_app.config['CLASSIC_COOKIE_NAME']
     session_cookie = request.cookies.get(session_cookie_key, None)
     classic_cookie = request.cookies.get(classic_cookie_key, None)
-    next_page = _checked_next_page()
-    logger.debug('Request to log out, then redirect to %s', next_page)
+    safe_next_page = _checked_next_page()
+    logger.debug('Request to log out, then redirect to %s', safe_next_page)
     data, code, headers = authentication.logout(session_cookie, classic_cookie,
-                                                next_page)
+                                                safe_next_page)
     # Flask puts cookie-setting methods on the response, so we do that here
     # instead of in the controller.
     if code is status.HTTP_303_SEE_OTHER:
@@ -176,7 +176,7 @@ def logout() -> Response:
         # Partial fix for ARXIVNG-1653, ARXIVNG-1644
         unset_permanent_cookie(response)
         return response
-    return redirect(next_page, code=status.HTTP_302_FOUND)
+    return redirect(safe_next_page, code=status.HTTP_302_FOUND)
 
 
 # @blueprint.route('/captcha', methods=['GET'])

--- a/accounts/accounts/tests/test_end_to_end.py
+++ b/accounts/accounts/tests/test_end_to_end.py
@@ -699,3 +699,30 @@ class TestLoginLogoutRoutes(TestCase):
         self.assertEqual(response.status_code, status.HTTP_303_SEE_OTHER)
 
         assert bad_next_page not in response.headers['Location'] #  redirect should NOT point at value of `bad_next_page` param
+
+        # Now client should be logged in
+
+        bad_next_page = 'https://bbc.co.uk'
+        response = client.post(f'/login?next_page={bad_next_page}', data=form_data)
+        self.assertEqual(response.status_code, status.HTTP_303_SEE_OTHER)
+        assert bad_next_page not in response.headers['Location'] #  redirect should NOT point at value of `bad_next_page` param
+
+
+
+    def test_post_login_with_next_page_implicit_protocol(self):
+        """POST request to /login with valid form data but bad next_page."""
+        client = self.app.test_client()
+        client.environ_base = self.environ_base
+        form_data = {'username': 'foouser', 'password': 'thepassword'}
+        bad_next_page = '//bbc.co.uk'
+        response = client.post(f'/login?next_page={bad_next_page}', data=form_data)
+        self.assertEqual(response.status_code, status.HTTP_303_SEE_OTHER)
+        assert bad_next_page not in response.headers['Location'] #  redirect should NOT point at value of `bad_next_page` param
+        assert "bbc" not in response.headers['Location'] #  redirect should NOT point at value of `bad_next_page` param
+
+        # Now client should be logged in
+        bad_next_page = '//bbc.co.uk'  # implied protocol, gets a https: added by client browser on redirect
+        response = client.post(f'/login?next_page={bad_next_page}', data=form_data)
+        self.assertEqual(response.status_code, status.HTTP_303_SEE_OTHER)
+        assert bad_next_page not in response.headers['Location'] #  redirect should NOT point at value of `bad_next_page` param
+        assert "bbc" not in response.headers['Location'] #  redirect should NOT point at value of `bad_next_page` param


### PR DESCRIPTION
This prevents off site next_page when the user is already logged in. It also prevents implicit URLs like `//example.com/steal_your_face`

The changes in PR #90 did not prevent these two things.

ARXIVCE-333