### PR TITLE
[ARXIVCE-4426] add SFI logo to footer; auth 

### DIFF
--- a/accounts/accounts/templates/accounts/base.html
+++ b/accounts/accounts/templates/accounts/base.html
@@ -102,8 +102,12 @@
     <div class="ds-site-footer-funders" aria-label="Major funders">
       <div class="ds-site-footer-funders-label">Major funding support from</div>
       <div class="ds-site-footer-funders-logos">
-        <img class="ds-funder-logo" src="{{ config.BASE_STATIC }}/images/funders/simons-foundation.png" alt="Simons Foundation">
-        <img class="ds-funder-logo" src="{{ config.BASE_STATIC }}/images/funders/schmidt-sciences.png" alt="Schmidt Sciences">
+        <a class="ds-funder-link" href="https://www.simonsfoundation.org/" target="_blank" rel="noopener noreferrer">
+          <img class="ds-funder-logo" src="{{ config.BASE_STATIC }}/images/funders/simons-foundation.png" alt="Simons Foundation"></a>
+        <a class="ds-funder-link" href="https://www.sfi.org.bm/" target="_blank" rel="noopener noreferrer">
+          <img class="ds-funder-logo" src="{{ config.BASE_STATIC }}/images/funders/simons-foundation-international.png" alt="Simons Foundation International"></a>
+        <a class="ds-funder-link" href="https://www.schmidtsciences.org/" target="_blank" rel="noopener noreferrer">
+          <img class="ds-funder-logo" src="{{ config.BASE_STATIC }}/images/funders/schmidt-sciences.png" alt="Schmidt Sciences"></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This branch builds on the header/footer work we deployed a week ago, now properly using `production` as base.