### PR TITLE
ARXIVCE-4313: update copyright notice to arXiv, Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,28 @@
-Copyright (c) arXiv, Inc.
+Copyright (c) 2026 arXiv, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Contributions made on or before June 30, 2026 are:
+
+Copyright (c) 2017-2025 Cornell University
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017 Cornell University
+Copyright (c) arXiv, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
⚠️ **DO NOT MERGE without checking with Jake Weiskoff (jake@arxiv.org) first.**
The copyright holder/year wording for ARXIVCE-4313 is not finalized. This PR is review-ready but must not be merged until Jake gives the go-ahead.

Part of the arXiv spinout from Cornell (ARXIVCE-4313). Updates the LICENSE copyright holder to `arXiv, Inc.` and drops the year, per direction to normalize all repos org-wide.