### PR TITLE
Bdc34/start round down

### DIFF
--- a/arxiv-auth/arxiv_auth/auth/sessions/store.py
+++ b/arxiv-auth/arxiv_auth/auth/sessions/store.py
@@ -87,7 +87,7 @@ class SessionStore(object):
         """
         if session_id is None:
             session_id = str(uuid.uuid4())
-        start_time = datetime.now(tz=UTC)
+        start_time = datetime.now(tz=UTC).replace(microsecond=0)  # round down to avoid unauth
         end_time = start_time + timedelta(seconds=self._duration)
         session = domain.Session(
             session_id=session_id,

--- a/arxiv-auth/arxiv_auth/legacy/sessions.py
+++ b/arxiv-auth/arxiv_auth/legacy/sessions.py
@@ -148,7 +148,7 @@ def create(authorizations: domain.Authorizations,
         raise SessionCreationFailed('Legacy sessions require a user')
 
     logger.debug('create session for user %s', user.user_id)
-    start = datetime.now(tz=UTC)
+    start = datetime.now(tz=UTC).replace(microsecond=0)  # round down to avoid unauth
     end = start + timedelta(seconds=util.get_session_duration())
     try:
         tapir_session = DBSession(


### PR DESCRIPTION
@ntai-arxiv noticed that the start time can be in the future if the microseconds cause the seconds to round up. This causes an unauthroized if the `next_page` is an api and is called very soon after the auth. He made a PR with a fix for this in `arxiv-base`'s auth code but that is not what is in production right now for `arxiv.org/login`. This is the code that is in production for `arxiv.org/login`.  