### PR TITLE
Removes write to Redis from /login

### DIFF
--- a/.github/workflows/pullrequest_tests.yaml
+++ b/.github/workflows/pullrequest_tests.yaml
@@ -31,9 +31,4 @@ jobs:
         run: |
           pip install pylint
           ./tests/lint.sh arxiv-auth accounts
-      - name: style check
-        run: |
-          pip install pydocstyle
-          ./tests/style.sh arxiv-auth/arxiv_auth accounts/accounts
-
 

--- a/.github/workflows/pullrequest_tests.yaml
+++ b/.github/workflows/pullrequest_tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install pip and poetry
         run: |
           python -m pip install --upgrade pip
-          python -m pip install poetry
+          python -m pip install 'poetry<2.0'
       - name: Install and test arxiv-auth
         working-directory: ./arxiv-auth
         run: |

--- a/accounts/README.md
+++ b/accounts/README.md
@@ -5,7 +5,7 @@ the `/login` `/logout` and other pages.
 
 ```bash
 cd accounts/
-pip install poetry
+pip install 'poetry<2.0'
 poetry install  # installs to a venv
 poetry shell    # activates the venv
 pytest
@@ -68,8 +68,9 @@ create tables. Conventional read/write access should be sufficient.
 ## Need to reinstall arxiv-auth
 If you are doing local development and make a change to arxiv-auth and want have
 that change in `accounts` you will need to reinstall `arxiv-auth` by running
-`poetry install`. Flask's auto-restart of the service in debug mod will not pick
-up changes to `arxiv-auth`.
+`poetry install` or `pip install arxiv-auth --force-reinstall --no-deps`.
+Flask's auto-restart of the service in debug mod will not pick up changes to
+`arxiv-auth`.
 
 ## TODO
 - Password reset in ``arxiv.users.legacy.accounts`` and in the accounts service.

--- a/accounts/accounts/controllers/authentication.py
+++ b/accounts/accounts/controllers/authentication.py
@@ -16,7 +16,7 @@ import logging
 
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import InternalServerError
-from flask import Markup
+from flask import Markup, current_app
 
 from wtforms import StringField, PasswordField, Form
 from wtforms.validators import DataRequired
@@ -27,7 +27,7 @@ from arxiv import status
 
 from arxiv_auth.domain import User, Authorizations, Session
 
-from arxiv_auth.auth.sessions import SessionStore
+from arxiv_auth.auth.sessions.store import _generate_nonce, pack_cookie
 
 from arxiv_auth.legacy import exceptions, sessions as legacy_sessions
 from arxiv_auth.legacy.authenticate import authenticate
@@ -46,9 +46,10 @@ def login(method: str, form_data: MultiDict, ip: str,
     """
     Provide the login form and handles login if the form data is POSTed.
 
-    This will attempt to create both a NG style `ARXIVNG_SESSION_ID` cookie with
-    a session in redis and legacy style `tapir_session` cookie with a session in
-    the DB.
+    This creates a legacy style `tapir_session` cookie backed by a session in
+    the legacy DB, and derives a NG style `ARXIVNG_SESSION_ID` cookie from it.
+    The NG cookie is a self-contained signed JWT, so no Redis distributed session
+    store is involved.
 
     Parameters
     ----------
@@ -69,7 +70,6 @@ def login(method: str, form_data: MultiDict, ip: str,
         Headers to add to the response.
 
     """
-    sessions = SessionStore.current_session()
     if method == 'GET':
         logger.debug('Request for login form')
         # TODO: If a permanent token is provided, attempt to log the user in,
@@ -113,15 +113,6 @@ def login(method: str, form_data: MultiDict, ip: str,
         })
         return data, status.HTTP_400_BAD_REQUEST, {}
 
-    try:    # Create a session in the distributed session store.
-        session = sessions.create(auths, ip, ip, track, user=user)
-        cookie = sessions.generate_cookie(session)
-        logger.debug('Created session: %s', session.session_id)
-    except sessions.exceptions.SessionCreationFailed as e:
-        logger.debug('Could not create session: %s', e)
-        logger.info('Could not create session: %s', e)
-        raise InternalServerError('Cannot log in') from e  # type: ignore
-
     try:    # Create a session in the legacy session store.
         c_session, c_cookie = _do_login(auths, ip, track, user)
     except exceptions.SessionCreationFailed as e:
@@ -129,10 +120,13 @@ def login(method: str, form_data: MultiDict, ip: str,
         logger.info('Could not create legacy session: %s', e)
         raise InternalServerError('Cannot log in') from e  # type: ignore
 
+    c_session.nonce = _generate_nonce()
+    cookie = pack_cookie(c_session, current_app.config['JWT_SECRET'])
+
     # The UI route should use these to set cookies on the response.
     data.update({
         'cookies': {
-            'auth_session_cookie': (cookie, session.expires),
+            'auth_session_cookie': (cookie, c_session.expires),
             'classic_cookie': (c_cookie, c_session.expires)
         }
     })
@@ -148,10 +142,11 @@ def logout(session_cookie: Optional[str],
 
     Parameters
     ----------
-    session_id : str or None
-        If not None, invalidates the session.
-    classic_session_id : str or None
-        If not None, invalidates the session.
+    session_cookie : str or None
+        Unused; the NG session is stateless and is ended by clearing the cookie.
+        Retained so the route signature does not change.
+    classic_session_cookie : str or None
+        If not None, invalidates the legacy session.
     next_page : str
         Page to which the user should be redirected upon logout.
 
@@ -166,13 +161,8 @@ def logout(session_cookie: Optional[str],
 
     """
     logger.debug('Request to log out')
-    sessions = SessionStore.current_session()
-    if session_cookie:
-        try:
-            sessions.delete(session_cookie)
-        except sessions.exceptions.SessionDeletionFailed as e:
-            logger.debug('Logout failed: %s', e)
-
+    # The NG session cookie is stateless, so clearing it (below) is all that is
+    # needed. Only the legacy session needs to be invalidated server-side.
     if classic_session_cookie:
         try:
             with transaction():

--- a/accounts/accounts/controllers/tests/test_authentication.py
+++ b/accounts/accounts/controllers/tests/test_authentication.py
@@ -1,8 +1,10 @@
 """Tests for mod:`accounts.controllers`."""
 import os
 from unittest import TestCase, mock
-from datetime import datetime
+from datetime import datetime, timedelta
 from pytz import timezone, UTC
+
+import jwt
 
 import hashlib
 from base64 import b64encode
@@ -107,13 +109,10 @@ class TestAuthenticationController(TestCase):
                 session.add(db_nick)
                 session.add(db_demo)
 
-    @mock.patch('accounts.controllers.authentication.SessionStore')
     @mock.patch('accounts.controllers.authentication.legacy_sessions')
-    def test_logout(self, mock_legacy_ses, mock_SessionStore):
+    def test_logout(self, mock_legacy_ses):
         """A logged-in user requests to log out."""
         mock_legacy_ses.invalidate_session.return_value = None
-        mock_SessionStore.current_session.return_value \
-            .delete.return_value = None
         next_page = '/'
         session_id = 'foosession'
         classic_id = 'bazsession'
@@ -124,13 +123,10 @@ class TestAuthenticationController(TestCase):
         self.assertEqual(header['Location'], next_page,
                          "Redirects user to next page.")
 
-    @mock.patch('accounts.controllers.authentication.SessionStore')
     @mock.patch('accounts.controllers.authentication.legacy_sessions')
-    def test_logout_anonymous(self, mock_legacy_ses, mock_SessionStore):
+    def test_logout_anonymous(self, mock_legacy_ses):
         """An anonymous user requests to log out."""
         mock_legacy_ses.invalidate_session.return_value = None
-        mock_SessionStore.current_session.return_value \
-            .delete.return_value = None
         next_page = '/'
         with self.app.app_context():
             data, status_code, header = logout(None, None, next_page)
@@ -139,8 +135,7 @@ class TestAuthenticationController(TestCase):
         self.assertEqual(header['Location'], next_page,
                          "Redirects user to next page.")
 
-    @mock.patch('accounts.controllers.authentication.SessionStore')
-    def test_login(self, mock_SessionStore):
+    def test_login(self):
         """User requests the login page."""
         with self.app.app_context():
             data, status_code, header = login('GET', {}, '', '')
@@ -150,8 +145,7 @@ class TestAuthenticationController(TestCase):
         self.assertEqual(status_code, status.HTTP_200_OK)
 
 
-    @mock.patch('accounts.controllers.authentication.SessionStore')
-    def test_post_invalid_data(self, mock_SessionStore):
+    def test_post_invalid_data(self):
         """User submits invalid data."""
         form_data = MultiDict({'username': 'foouser'})     # Missing password.
         next_page = '/next'
@@ -182,14 +176,14 @@ class TestAuthenticationController(TestCase):
                               "Response includes a login form.")
 
     @mock.patch('accounts.controllers.authentication.legacy_sessions')
-    @mock.patch('accounts.controllers.authentication.SessionStore')
     @mock.patch('accounts.controllers.authentication.authenticate')
-    def test_post_great(self, mock_authenticate, mock_SessionStore, mock_session):
+    def test_post_great(self, mock_authenticate, mock_session):
         """Form data are valid and check out."""
         form_data = MultiDict({'username': 'foouser', 'password': 'bazpass'})
         ip = '123.45.67.89'
         next_page = '/foo'
         start_time = datetime.now(tz=UTC)
+        end_time = start_time + timedelta(seconds=self.expiry)
         user = domain.User(
             user_id="42",
             username='foouser',
@@ -205,41 +199,39 @@ class TestAuthenticationController(TestCase):
             session_id='barsession',
             user=user,
             start_time=start_time,
+            end_time=end_time,
             authorizations=auths
         )
         c_cookie = 'bardata'
         mock_session.create.return_value = c_session
         mock_session.generate_cookie.return_value = c_cookie
-        session = domain.Session(
-            session_id='foosession',
-            user=user,
-            start_time=start_time,
-            authorizations=domain.Authorizations(
-                scopes=['public:read', 'submission:create']
-            )
-        )
-        cookie = 'foodata'
-        mock_SessionStore.current_session.return_value \
-            .create.return_value = session
-        mock_SessionStore.current_session.return_value \
-            .generate_cookie.return_value = cookie
 
         with self.app.app_context():
             data, status_code, header = login('POST', form_data, ip, next_page)
+            jwt_secret = self.app.config['JWT_SECRET']
         self.assertEqual(status_code, status.HTTP_303_SEE_OTHER,
                          "Redirects user to next page")
         self.assertEqual(header['Location'], next_page,
                          "Redirects user to next page.")
-        self.assertEqual(data['cookies']['auth_session_cookie'],
-                         (cookie, None),
-                         "Session cookie is returned")
-        self.assertEqual(data['cookies']['classic_cookie'], (c_cookie, None),
+        self.assertEqual(data['cookies']['classic_cookie'],
+                         (c_cookie, c_session.expires),
                          "Classic session cookie is returned")
 
-    @mock.patch('accounts.controllers.authentication.SessionStore')
+        ng_cookie, ng_expires = data['cookies']['auth_session_cookie']
+        self.assertAlmostEqual(ng_expires, self.expiry, delta=2,
+                               msg="NG cookie expires with the legacy session")
+        claims = jwt.decode(ng_cookie, jwt_secret, algorithms=['HS256'])
+        self.assertEqual(claims['user_id'], user.user_id,
+                         "NG cookie carries the user ID")
+        self.assertEqual(claims['session_id'], c_session.session_id,
+                         "NG cookie is derived from the legacy session")
+        self.assertEqual(claims['expires'], end_time.isoformat(),
+                         "NG cookie expiry matches the legacy session")
+        self.assertIn('nonce', claims, "NG cookie carries a nonce")
+
     @mock.patch('accounts.controllers.authentication.legacy_sessions')
     @mock.patch('accounts.controllers.authentication.authenticate')
-    def test_post_not_verified(self, mock_authenticate, mock_legacy_sess, mock_SessionStore):
+    def test_post_not_verified(self, mock_authenticate, mock_legacy_sess):
         """Form data are valid and check out."""
         form_data = MultiDict({'username': 'foouser', 'password': 'bazpass'})
         ip = '123.45.67.89'
@@ -265,19 +257,6 @@ class TestAuthenticationController(TestCase):
         c_cookie = 'bardata'
         mock_legacy_sess.create.return_value = c_session
         mock_legacy_sess.generate_cookie.return_value = c_cookie
-        session = domain.Session(
-            session_id='foosession',
-            user=user,
-            start_time=start_time,
-            authorizations=domain.Authorizations(
-                scopes=['public:read', 'submission:create']
-            )
-        )
-        cookie = 'foodata'
-        mock_SessionStore.current_session.return_value \
-            .create.return_value = session
-        mock_SessionStore.current_session.return_value \
-            .generate_cookie.return_value = cookie
 
         with self.app.app_context():
             data, status_code, header = login('POST', form_data, ip, next_page)

--- a/accounts/pyproject.toml
+++ b/accounts/pyproject.toml
@@ -3,6 +3,7 @@ name = "arxiv-accounts"
 version = "1.1.0"
 description = "common auth parts of arXiv"
 authors = ["arxiv.org"]
+packages = [{ include = "accounts" }]
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/arxiv-auth/arxiv_auth/auth/sessions/store.py
+++ b/arxiv-auth/arxiv_auth/auth/sessions/store.py
@@ -32,6 +32,30 @@ def _generate_nonce(length: int = 8) -> str:
     return ''.join([str(random.randint(0, 9)) for i in range(length)])
 
 
+def pack_cookie(session: domain.Session, secret: str) -> str:
+    """Generate the `ARXIVNG_SESSION_ID` cookie value for a session.
+
+    The cookie is a self-contained signed JWT. Consumers verify its signature
+    rather than looking the session up in this store (see
+    `arxiv.cloud_auth.domain.Auth` for the claims they expect), so this needs no
+    connection and can be used for sessions that live only in the legacy DB.
+    """
+    if session.end_time is None:
+        raise RuntimeError('Session has no expiry')
+    if session.user is None:
+        raise RuntimeError('Session user is not set')
+    if session.nonce is None:
+        # A null nonce fails validation in consumers that model it as a
+        # required str, so refuse to mint a cookie that cannot be used.
+        raise RuntimeError('Session nonce is not set')
+    return jwt.encode({
+        'user_id': session.user.user_id,
+        'session_id': session.session_id,
+        'nonce': session.nonce,
+        'expires': session.end_time.isoformat()
+    }, secret)
+
+
 class SessionStore(object):
     """
     Manages a connection to Redis.
@@ -112,16 +136,7 @@ class SessionStore(object):
 
     def generate_cookie(self, session: domain.Session) -> str:
         """Generate a cookie from a :class:`domain.Session`."""
-        if session.end_time is None:
-            raise RuntimeError('Session has no expiry')
-        if session.user is None:
-            raise RuntimeError('Session user is not set')
-        return self._pack_cookie({
-            'user_id': session.user.user_id,
-            'session_id': session.session_id,
-            'nonce': session.nonce,
-            'expires': session.end_time.isoformat()
-        })
+        return pack_cookie(session, self._secret)
 
     def delete(self, cookie: str) -> None:
         """


### PR DESCRIPTION
NG arxiv-auth /login wrote to Redis at AWS. It never read from redis. 

This PR removes use of Redis. 

Soon after deploy of the arxiv-auth AWS elasticache redis cluster can be shutdown. 

I tested this on web8 

1. setup iptables to report any traffic to the redis ips
2. check that /login made traffic (/login worked and there was traffic to redis on the /login page draw and login POST)
3. setup iptables to block traffic to redis ips
4. checked that /login failed (it did)
5. deployed this branch that cut out redis (I had some problems here to get the code installed)
6. Tested /login (it worked, as did logout)
7. success!

This does not use FakeRedis since that writes a warning to the log every time it is called.